### PR TITLE
Fix problem with WordPress 6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ If this plugin has been handy to you, you can keep up the work by donating to be
 `TA6NCxJ97WsCDmUVEEvsVz1PW4kAVza295` (Any TRC20 (Tron network) tokens)
 
 ## Changelog
+### 0.5.3
+* Fixed incompability with WordPress 6.1
 
 ### 0.5.2
 

--- a/inc/admin/class-specification-tables.php
+++ b/inc/admin/class-specification-tables.php
@@ -38,7 +38,7 @@ class Specification_Tables
 	public static function save_table_metabox( $post_id ){
 		if( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) return;
 		if( !isset( $_POST['dwps_metabox_nonce'] ) || !wp_verify_nonce( $_POST['dwps_metabox_nonce'], 'dw-specs-table-metas' ) ) return;
-		if( !current_user_can( 'edit_post' ) ) return;
+		if( !current_user_can( 'edit_post', $post_id ) ) return;
 		if( $_POST['post_type'] !== 'specs-table' ) return;
 		if( !isset( $_POST['groups'] ) || !is_array( $_POST['groups'] ) ) return;
 
@@ -60,7 +60,7 @@ class Specification_Tables
 	public static function save_product_table( $post_id ){
 		if( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) return;
 		if( !isset( $_POST['dwps_metabox_nonce'] ) || !wp_verify_nonce( $_POST['dwps_metabox_nonce'], 'dw-specs-table-metas' ) ) return;
-		if( !current_user_can( 'edit_post' ) ) return;
+		if( !current_user_can( 'edit_post', $post_id ) ) return;
 		if( !in_array( $_POST['post_type'], array('product') ) ) return;
 		if( !isset( $_POST['specs_table'] ) || empty( $_POST['specs_table'] ) || $_POST['specs_table'] == '0' ||  $_POST['specs_table'] == 0 ) return;
 

--- a/inc/class-app.php
+++ b/inc/class-app.php
@@ -20,7 +20,7 @@ final class App
 	 *
 	 * @var string
 	 */
-    public $version = '0.5.2';
+    public $version = '0.5.3';
 
     /**
      * Plugin instance.

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@
 Contributors: dornaweb
 Tags: product specifications,product specs,product specifications table,product attributes table,product attributes, woocommerce, woocommerce product specifications, product details, product information, product table
 Requires at least: 5.1
-Tested up to: 5.9.1
-Stable tag: 0.5.2
+Tested up to: 6.1
+Stable tag: 0.5.3
 Requires PHP: 5.6
 License: GNU GPL V2. or later
 License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
@@ -81,6 +81,12 @@ function my_custom_spec_table_markup( $output, $args ){
 
 
 == Changelog ==
+
+== 0.5.3 ==
+* Fixed incompability with WordPress 6.1
+
+== 0.5.2 ==
+* Fixed incompability with php 8.0
 
 == 0.5.1 ==
 * Selectbox Saving issue fixed

--- a/wc-specs.php
+++ b/wc-specs.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Product Specifications for WooCommerce
  * Plugin URI: 		  https://wwww.dornaweb.com/
  * Description:       This plugin adds a product specifications table to your woocommerce products.
- * Version:           0.5.2
+ * Version:           0.5.3
  * Author:            Am!n A.Rezapour
  * Author URI: 		  https://www.dornaweb.com
  * License:           GPL-2.0+


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?**
Bug fix


**What is the current behavior?**
As reported [here](https://wordpress.org/support/topic/specification-table-couldnt-update/) and [here](https://wordpress.org/support/topic/not-working-latest-release-wordpress-6-1/) specifications table and also product specs attributes are not saved.

**What is the new behavior (if this is a feature change)?**
Problem occurs at `current_user_can` check ([see here](https://github.com/dornaweb/product-specifications/blob/0.5.2/inc/admin/class-specification-tables.php#L63)) where it needs post_id to be explicitly passed to the function.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No