### PR TITLE
Fix file path in admin get template

### DIFF
--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -61,7 +61,7 @@ class Admin
 		if( empty( $template ) ) return; // Ignore if $template is empty
 
 		extract( $args );
-		include( DWSPECS_ABSPATH . 'src/admin/' . $template . '.php' );
+		include( DWSPECS_ABSPATH . 'src/Admin/' . $template . '.php' );
 	}
 
 	/**


### PR DESCRIPTION
Wrong Case-insensitive file path in the `Admin::get_template()` caused failure in resolving template files.