### PR TITLE
chore: disable automatic release on tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: 🚀 Release to WordPress.org plugins repo
 on:
-  release:
-    types: [published, edited]
+  workflow_dispatch:
 jobs:
   tag:
     name: 🎉 New Release


### PR DESCRIPTION
Temporarily disable Automatic releases to WordPress repository upon creating tags.