### PR TITLE
fix: broken options in field type "select" and "radio"

### DIFF
--- a/src/EntityUpdater/AttributeController.php
+++ b/src/EntityUpdater/AttributeController.php
@@ -302,14 +302,12 @@ final class AttributeController
         $description = (string) filter_input(INPUT_POST, 'attr_desc', FILTER_SANITIZE_SPECIAL_CHARS);
         $group = (string) filter_input(INPUT_POST, 'attr_group', FILTER_SANITIZE_SPECIAL_CHARS);
         $type = (string) filter_input(INPUT_POST, 'attr_type', FILTER_SANITIZE_SPECIAL_CHARS);
-        $values = array_filter(
-            (array) filter_input(
-                INPUT_POST,
-                'attr_values',
-                FILTER_SANITIZE_SPECIAL_CHARS,
-                FILTER_FORCE_ARRAY
-            )
+        $values = (string) filter_input(
+            INPUT_POST,
+            'attr_values',
+            FILTER_SANITIZE_FULL_SPECIAL_CHARS
         );
+        $values = !empty($values) ? explode(PHP_EOL, $values) : [];
         $default = $this->defaultValue($type);
         $id = (int) filter_input(INPUT_POST, 'group_id', FILTER_SANITIZE_NUMBER_INT) ?: 0;
 


### PR DESCRIPTION
During refactoring the plugin, a bug has been introduced where options of "select" and "radio" field types were broken.