### PR TITLE
docs: add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,47 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+
+---
+
+## Describe the bug
+A clear and concise description of what the bug is.
+
+## Steps To Reproduce
+
+<!--
+Please write steps reproduce this bug, for example:
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+-->
+
+## Expected behavior
+<!--
+A clear and concise description of what you expected to happen.
+-->
+
+## Actual behavior
+<!--
+A clear and concise description of what you get instead.
+-->
+
+## Screenshots
+<!--
+If applicable, screenshots or videos to help explain the problem, this is nice-to-have but it is not mandatory
+-->
+
+## Environment (please complete the following information)
+ - Browser:
+ - Product Specifications version:
+ - WordPress Version:
+ - WooCommerce version:
+
+## Additional context
+<!--
+Add any other context about the problem here.
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: General Help Request
+    url: https://wordpress.org/support/plugin/product-specifications/
+    about: Please ask and answer non-development related questions here.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,28 @@
+---
+name: Feature request
+about: Suggest an idea or enhancement for this project
+title: ''
+assignees: ''
+
+---
+
+## About your feature request
+<!--
+Please explain about your feature request or enhancement.
+-->
+
+
+## Describe the solution you'd like
+<!--
+Describe your concise proposed solution (optional).
+-->
+
+## Describe alternatives you've considered
+<!--
+A clear and concise description of any alternative solutions or features you've considered. (optional)
+-->
+
+## Additional context
+<!--
+Add any other context or screenshots about the feature request here.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+## Description
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
+
+<!-- Remove below line if not applicable -->
+Fixes # (issue)
+
+## Summary of changes in this PR
+<!-- Use [x] to mark relevant options, feel free to delete lines that are not applicable -->
+
+This PR:
+- [ ] **Fixes a bug**
+- [ ] **Introduces a new feature**
+- [ ] **Introduces enhancements in existing functionality**
+- [ ] **Updates documents**
+- [ ] **Adds or Updates tests**
+- [ ] **Introduces BREAKING CHANGES**
+
+## How Has This Been Tested?
+<!--
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
+-->
+
+## Checklist:
+<!-- Use [x] to mark relevant options, feel free to delete lines that are not applicable -->
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new CS errors or warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes


### PR DESCRIPTION
Add Github templates for issues (two types, bug report and feature request) and pull requests.