### PR TITLE
fix: new lines in textarea fields are removed

### DIFF
--- a/src/ProductSpecifications/ProductSpecificationsMetabox.php
+++ b/src/ProductSpecifications/ProductSpecificationsMetabox.php
@@ -150,6 +150,12 @@ final class ProductSpecificationsMetabox implements Metabox
                 continue;
             }
 
+            $type = (string) get_term_meta($attribute->term_id, 'attr_type', true);
+
+            if ($type === 'textarea') {
+                $value = $this->preserveNewLines((string) $value);
+            }
+
             $result[] = [
                 'attr_id' => $attributeId,
                 'attr_name' => $attribute->name,
@@ -160,5 +166,14 @@ final class ProductSpecificationsMetabox implements Metabox
         }
 
         return $result;
+    }
+
+    private function preserveNewLines(string $string): string
+    {
+        return str_replace(
+            ['&#10;', '&#xa;', '&#x0a;', '&#013;', '&#xd;', '&#x0d;', "\r\n", "\r"],
+            PHP_EOL,
+            $string
+        );
     }
 }


### PR DESCRIPTION
## Description
This PR fixes an issue in which the text-area fields do not preserve new lines, the new lines are escaped in sanitization function, therefore can't be converted into line-breaks (`<br />`) correctly.

<!-- Remove below line if not applicable -->
Fixes #40 

## Summary of changes in this PR
Preserve new lines in text-area fields.

This PR:
- [x] **Fixes a bug**
- [ ] **Introduces a new feature**
- [ ] **Introduces enhancements in existing functionality**
- [ ] **Updates documents**
- [ ] **Adds or Updates tests**
- [ ] **Introduces BREAKING CHANGES**

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new CS errors or warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Other information:
The downside of this bug is that, products that have been affected and have been saved recently need to be re-saved so that the line breaks are saved as part of the field values, old products are of course unaffected.