### PR TITLE
fix: prevent displaying encoded group slugs

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -36,7 +36,7 @@ if (!function_exists('dwspecs_get_attributes_by_group')) {
  * @return mixed
 */
 if (!function_exists('dwspecs_attr_value_by')) {
-    function dwspecs_attr_value_by($post_id = '', $field, $value)
+    function dwspecs_attr_value_by($post_id, $field, $value)
     {
 
         if (!$post_id) {

--- a/templates/admin/attribute-groups/list-page.php
+++ b/templates/admin/attribute-groups/list-page.php
@@ -97,7 +97,7 @@ defined('ABSPATH') || exit;
                                     </h4>
                                 </td>
                                 <td>
-                                    <?= esc_html($group->slug) ?>
+                                    <?= esc_html(urldecode($group->slug)) ?>
                                 </td>
                                 <td>
                                     <?= esc_html(sizeof($attributes)) ?>

--- a/templates/admin/metabox/specifications-table/table-metabox.php
+++ b/templates/admin/metabox/specifications-table/table-metabox.php
@@ -46,7 +46,7 @@ defined('ABSPATH') || exit;
                             value="<?= esc_attr((string) $term->term_id) ?>"
                             <?php checked($isChecked) ?>
                         >
-                        <span><?= esc_html($term->name) ?><?= esc_html($slug) ?></span>
+                        <span><?= esc_html($term->name) ?><?= esc_html(urldecode($slug)) ?></span>
                     </label>
                 </p>
             <?php endforeach ?>


### PR DESCRIPTION
## Description
Currently group slugs are shown as encoded strings, causing readability issues more in languages with utf8 characters.
In addition a PHP notice is fixed as boy scout rule.

## Summary of changes in this PR

This PR:
- [x] **Fixes a bug**
- [ ] **Introduces a new feature**
- [x] **Introduces enhancements in existing functionality**
- [ ] **Updates documents**
- [ ] **Adds or Updates tests**
- [ ] **Introduces BREAKING CHANGES**

## How Has This Been Tested?
- Groups slugs are displayed properly
- PHP notice disappeared from logs.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new CS errors or warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
