### PR TITLE
Add HPOS compatibility declaration

### DIFF
--- a/src/Integration/Module.php
+++ b/src/Integration/Module.php
@@ -6,12 +6,14 @@ namespace Amiut\ProductSpecs\Integration;
 
 use Amiut\ProductSpecs\Assets\AssetHelper;
 use Amiut\ProductSpecs\Integration\WooCommerce\Assets;
+use Amiut\ProductSpecs\Integration\WooCommerce\FeaturesCompatibilityDeclarations;
 use Amiut\ProductSpecs\Integration\WooCommerce\ProductTabs;
 use Amiut\ProductSpecs\Integration\WooCommerce\WooCommerceNotInstalledNoticeHandler;
 use Amiut\ProductSpecs\Repository\SpecificationsTableRepository;
 use Inpsyde\Modularity\Module\ExecutableModule;
 use Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
 use Inpsyde\Modularity\Module\ServiceModule;
+use Inpsyde\Modularity\Package;
 use Psr\Container\ContainerInterface;
 
 final class Module implements ServiceModule, ExecutableModule
@@ -28,11 +30,19 @@ final class Module implements ServiceModule, ExecutableModule
             ProductTabs::class => static fn (ContainerInterface $container) => new ProductTabs(
                 $container->get(SpecificationsTableRepository::class)
             ),
+            FeaturesCompatibilityDeclarations::class => static fn (ContainerInterface $container) => new FeaturesCompatibilityDeclarations(
+                $container->get(Package::PROPERTIES)
+            ),
         ];
     }
 
     public function run(ContainerInterface $container): bool
     {
+        add_action(
+            'before_woocommerce_init',
+            $container->get(FeaturesCompatibilityDeclarations::class)
+        );
+
         add_filter(
             'woocommerce_product_tabs',
             [$container->get(ProductTabs::class), 'addProductSpecificationsTab']

--- a/src/Integration/WooCommerce/FeaturesCompatibilityDeclarations.php
+++ b/src/Integration/WooCommerce/FeaturesCompatibilityDeclarations.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Amiut\ProductSpecs\Integration\WooCommerce;
+
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+use Inpsyde\Modularity\Properties\PluginProperties;
+
+class FeaturesCompatibilityDeclarations
+{
+    private PluginProperties $pluginProperties;
+
+    public function __construct(PluginProperties $pluginProperties)
+    {
+        $this->pluginProperties = $pluginProperties;
+    }
+
+    public function __invoke()
+    {
+        $this->declareHposCompatibility();
+    }
+
+    private function declareHposCompatibility(): void
+    {
+        if (!class_exists(FeaturesUtil::class)) {
+            return;
+        }
+
+        FeaturesUtil::declare_compatibility(
+            'custom_order_tables',
+            $this->pluginProperties->pluginMainFile(),
+            true
+        );
+    }
+}


### PR DESCRIPTION
## Description
This PR fixes an issue where the following error is displayed when updating the plugin and in WooCommerce status page:

> WooCommerce has detected that some of your active plugins are incompatible with currently enabled WooCommerce features. Please review the details.

This plugin doesn't interact with WooCommerce orders and no actual changes in the codes is required, we just declare compatibility to avoid displaying this error message.

Fixes #46 

## Summary of changes in this PR
This PR:
- [ ] **Fixes a bug**
- [ ] **Introduces a new feature**
- [x] **Introduces enhancements in existing functionality**
- [ ] **Updates documents**
- [ ] **Adds or Updates tests**
- [ ] **Introduces BREAKING CHANGES**

## How Has This Been Tested?
The mentioned error message is no longer displayed in plugins list page and in WooCommerce status page.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new CS errors or warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
