### PR TITLE
Rename entities terminology

### DIFF
--- a/src/Admin/Module.php
+++ b/src/Admin/Module.php
@@ -49,8 +49,8 @@ final class Module implements ServiceModule, ExecutableModule
     private function registerMenuPages(ContainerInterface $container): void
     {
         add_menu_page(
-            esc_html__('Product specifications table', 'product-specifications'),
-            esc_html__('Specs. tables', 'product-specifications'),
+            esc_html__('Product specifications', 'product-specifications'),
+            esc_html__('Product specs.', 'product-specifications'),
             'edit_pages',
             'dw-specs',
             static function (): void {
@@ -62,8 +62,8 @@ final class Module implements ServiceModule, ExecutableModule
         // Add tables page
         add_submenu_page(
             'dw-specs',
-            esc_html__('Add a new table', 'product-specifications'),
-            esc_html__('New table', 'product-specifications'),
+            esc_html__('Add a new specification bundle', 'product-specifications'),
+            esc_html__('New specification bundle', 'product-specifications'),
             'edit_pages',
             'dw-specs-new',
             static function (): void {

--- a/src/AttributeGroupsListUi/Module.php
+++ b/src/AttributeGroupsListUi/Module.php
@@ -41,7 +41,7 @@ final class Module implements ServiceModule, ExecutableModule
     {
         add_submenu_page(
             'dw-specs',
-            esc_html__('Attribute Groups', 'product-specifications'),
+            esc_html__('Specification Groups', 'product-specifications'),
             esc_html__('Groups', 'product-specifications'),
             'edit_pages',
             'dw-specs-groups',

--- a/src/AttributesListUi/Module.php
+++ b/src/AttributesListUi/Module.php
@@ -41,8 +41,8 @@ final class Module implements ServiceModule, ExecutableModule
     {
         add_submenu_page(
             'dw-specs',
-            esc_html__('Attributes', 'product-specifications'),
-            esc_html__('Attributes', 'product-specifications'),
+            esc_html__('Specifications', 'product-specifications'),
+            esc_html__('Specifications', 'product-specifications'),
             'edit_pages',
             'dw-specs-attrs',
             [$container->get(AttributeListPage::class), 'render']

--- a/src/Content/PostType/SpecificationsTable.php
+++ b/src/Content/PostType/SpecificationsTable.php
@@ -37,19 +37,19 @@ final class SpecificationsTable
     {
         return [
             'name' => esc_html__(
-                'Specifications tables',
+                'Specifications bundle',
                 'product-specifications'
             ),
             'singular_name' => esc_html__(
-                'Specifications table',
+                'Specifications bundle',
                 'product-specifications'
             ),
             'menu_name' => esc_html__(
-                'Specifications table',
+                'Specifications bundle',
                 'product-specifications'
             ),
             'name_admin_bar' => esc_html__(
-                'Specifications tables',
+                'Specifications bundle',
                 'product-specifications'
             ),
             'add_new' => esc_html__(
@@ -57,43 +57,43 @@ final class SpecificationsTable
                 'product-specifications'
             ),
             'add_new_item' => esc_html__(
-                'Add New Spec. table',
+                'Add New bundle',
                 'product-specifications'
             ),
             'new_item' => esc_html__(
-                'New Spec. table',
+                'New specification bundle',
                 'product-specifications'
             ),
             'edit_item' => esc_html__(
-                'Edit Spec. table',
+                'Edit bundle',
                 'product-specifications'
             ),
             'view_item' => esc_html__(
-                'View Spec. table',
+                'View bundle',
                 'product-specifications'
             ),
             'all_items' => esc_html__(
-                'Specification tables',
+                'Specification bundles',
                 'product-specifications'
             ),
             'search_items' => esc_html__(
-                'Search Spec. tables',
+                'Search bundle',
                 'product-specifications'
             ),
             'parent_item_colon' => esc_html__(
-                'Parent Spec. tables:',
+                'Parent bundle:',
                 'product-specifications'
             ),
             'not_found' => esc_html__(
-                'No Spec. tables found.',
+                'No bundle found.',
                 'product-specifications'
             ),
             'not_found_in_trash' => esc_html__(
-                'No Spec. tables found in Trash.',
+                'No bundle found in Trash.',
                 'product-specifications'
             ),
             'featured_image' => esc_html__(
-                'Spec. table Cover Image',
+                'set Cover Image',
                 'product-specifications'
             ),
             'set_featured_image' => esc_html__(
@@ -109,27 +109,27 @@ final class SpecificationsTable
                 'product-specifications'
             ),
             'archives' => esc_html__(
-                'Spec. tables archives',
+                'bundle archives',
                 'product-specifications'
             ),
             'insert_into_item' => esc_html__(
-                'Insert into Spec. table',
+                'Insert into bundle',
                 'product-specifications'
             ),
             'uploaded_to_this_item' => esc_html__(
-                'Uploaded to this Spec. table',
+                'Uploaded to this bundle',
                 'product-specifications'
             ),
             'filter_items_list' => esc_html__(
-                'Filter Spec. tables list',
+                'Filter bundle list',
                 'product-specifications'
             ),
             'items_list_navigation' => esc_html__(
-                'Spec. tables list navigation',
+                'bundle list navigation',
                 'product-specifications'
             ),
             'items_list' => esc_html__(
-                'Spec. tables list',
+                'bundle list',
                 'product-specifications'
             ),
         ];

--- a/src/Content/Taxonomy/Attribute.php
+++ b/src/Content/Taxonomy/Attribute.php
@@ -30,16 +30,16 @@ final class Attribute
     public static function labels(): array
     {
         return [
-            'name' => _x('Attributes', 'taxonomy general name', 'product-specifications'),
-            'singular_name' => _x('attribute', 'taxonomy singular name', 'product-specifications'),
-            'search_items' => __('Search in attributes', 'product-specifications'),
-            'all_items' => __('all attributes', 'product-specifications'),
-            'parent_item' => __('parent attribute', 'product-specifications'),
-            'parent_item_colon' => __('parent attribute : ', 'product-specifications'),
-            'edit_item' => __('Edit attribute', 'product-specifications'),
-            'update_item' => __('Update attribute', 'product-specifications'),
-            'add_new_item' => __('Add a new attribute', 'product-specifications'),
-            'new_item_name' => __('New attribute', 'product-specifications'),
+            'name' => _x('Specifications', 'taxonomy general name', 'product-specifications'),
+            'singular_name' => _x('specification', 'taxonomy singular name', 'product-specifications'),
+            'search_items' => __('Search in specifications', 'product-specifications'),
+            'all_items' => __('all specifications', 'product-specifications'),
+            'parent_item' => __('parent specification', 'product-specifications'),
+            'parent_item_colon' => __('parent specification : ', 'product-specifications'),
+            'edit_item' => __('Edit specification', 'product-specifications'),
+            'update_item' => __('Update specification', 'product-specifications'),
+            'add_new_item' => __('Add a new specification', 'product-specifications'),
+            'new_item_name' => __('New specification', 'product-specifications'),
         ];
     }
 }

--- a/src/EntityUpdater/AttributeController.php
+++ b/src/EntityUpdater/AttributeController.php
@@ -241,7 +241,7 @@ final class AttributeController
         wp_send_json_success(
             [
                 'result' => 'success',
-                'message' => esc_html__('Attribute(s) deleted successfully', 'product-specifications'),
+                'message' => esc_html__('Specification(s) deleted successfully', 'product-specifications'),
                 'action' => 'delete',
             ]
         );
@@ -254,7 +254,7 @@ final class AttributeController
     {
         if (empty($data['name'])) {
             throw new InvalidEntityPropertyException(
-                esc_html__('Please enter an attribute name', 'product-specifications'),
+                esc_html__('Please enter an specification name', 'product-specifications'),
                 'input#attr_name'
             );
         }
@@ -275,7 +275,7 @@ final class AttributeController
 
         if (($data['type'] === 'select' || $data['type'] === 'radio') && (empty($data['values']))) {
             throw new InvalidEntityPropertyException(
-                esc_html__('Please set some values for attribute', 'product-specifications'),
+                esc_html__('Please set some values for specification', 'product-specifications'),
                 'input#attr_values'
             );
         }

--- a/templates/admin/attribute-groups/list-page.php
+++ b/templates/admin/attribute-groups/list-page.php
@@ -19,12 +19,12 @@ defined('ABSPATH') || exit;
 
 <div class="dwps-page">
     <div class="dwps-settings-wrap">
-        <h3><?= esc_html__('Attribute Groups', 'product-specifications') ?></h3>
+        <h3><?= esc_html__('Specification Groups', 'product-specifications') ?></h3>
         <p class="title-note"></p>
 
         <div class="dwps-box-wrapper clearfix">
             <div class="dwps-box-top clearfix">
-                <h4><?= esc_html__('Attribute Groups', 'product-specifications') ?></h4>
+                <h4><?= esc_html__('Specification Groups', 'product-specifications') ?></h4>
                 <div class="dwps-group-searchform">
                     <form action="" method="get">
                         <input

--- a/templates/admin/attributes/list-page.php
+++ b/templates/admin/attributes/list-page.php
@@ -21,12 +21,12 @@ defined('ABSPATH') || exit;
 
 <div class="dwps-page">
     <div class="dwps-settings-wrap">
-        <h3><?= esc_html__('Attributes', 'product-specifications') ?></h3>
+        <h3><?= esc_html__('Product specifications', 'product-specifications') ?></h3>
         <p class="title-note"></p>
 
         <div class="dwps-box-wrapper clearfix">
             <div class="dwps-box-top clearfix">
-                <h4><?= esc_html__('Attributes', 'product-specifications') ?></h4>
+                <h4><?= esc_html__('product specifications', 'product-specifications') ?></h4>
                 <div class="dwps-group-searchform">
                     <form action="" method="get">
                         <input
@@ -53,7 +53,7 @@ defined('ABSPATH') || exit;
                     <tr>
                         <th class="check-column"><input type="checkbox" id="cb-select-all-1" class="selectall"></th>
                         <th><?= esc_html__('ID', 'product-specifications') ?></th>
-                        <th><?= esc_html__('Attribute name', 'product-specifications') ?></th>
+                        <th><?= esc_html__('Specification name', 'product-specifications') ?></th>
                         <th><?= esc_html__('Group name', 'product-specifications') ?></th>
                         <th><?= esc_html__('Actions', 'product-specifications') ?></th>
                     </tr>
@@ -206,17 +206,17 @@ defined('ABSPATH') || exit;
 <script id="modify_form_template" type="x-tmpl-mustache">
     <form action="#" method="post" id="dwps_modify_form">
         <p>
-            <label for="attr_name"><?= esc_html__('Attribute name : ', 'product-specifications') ?></label>
+            <label for="attr_name"><?= esc_html__('Specification name : ', 'product-specifications') ?></label>
             <input type="text" name="attr_name" value="" id="attr_name" aria-required="true">
         </p>
 
         <p>
-            <label for="attr_slug"><?= esc_html__('Attribute slug : ', 'product-specifications') ?></label>
+            <label for="attr_slug"><?= esc_html__('Specification slug : ', 'product-specifications') ?></label>
             <input type="text" name="attr_slug" value="" id="attr_slug" placeholder="<?= esc_attr__('Optional', 'product-specifications') ?>">
         </p>
 
     <p>
-        <label for="attr_group"><?= esc_html__('Attribute group : ', 'product-specifications') ?></label>
+        <label for="attr_group"><?= esc_html__('Specification group : ', 'product-specifications') ?></label>
             <select name="attr_group" id="attr_group" aria-required="true">
                 <option value=""><?= esc_html__('Select a group', 'product-specifications') ?></option>
     <?php
@@ -235,7 +235,7 @@ defined('ABSPATH') || exit;
 </p>
 
 <p>
-    <label for="attr_type"><?= esc_html__('Attribute field Type : ', 'product-specifications') ?></label>
+    <label for="attr_type"><?= esc_html__('Specification field Type : ', 'product-specifications') ?></label>
             <select name="attr_type" id="attr_type" aria-required="true">
                 <option value=""><?= esc_html__('Select a field type', 'product-specifications') ?></option>
                 <option value="text"><?= esc_html__('Text', 'product-specifications') ?>
@@ -264,6 +264,6 @@ defined('ABSPATH') || exit;
         <input type="hidden" name="action" value="dwps_modify_attributes">
         <input type="hidden" name="do" value="add">
     <?php wp_nonce_field('dwps_modify_attributes', 'dwps_modify_attributes_nonce') ?>
-    <input type="submit" value="<?= esc_attr__('Add attribute', 'product-specifications') ?>" class="button button-primary">
+    <input type="submit" value="<?= esc_attr__('Add Specification', 'product-specifications') ?>" class="button button-primary">
     </form>
 </script>

--- a/templates/admin/entity-management/edit-attribute-form.php
+++ b/templates/admin/entity-management/edit-attribute-form.php
@@ -20,17 +20,17 @@ $term = get_term_by('id', $attributeId, 'spec-attr');
 
 <form action="#" method="post" id="dwps_modify_form">
     <p>
-        <label for="attr_name"><?= esc_html__('Attribute name : ', 'product-specifications') ?></label>
+        <label for="attr_name"><?= esc_html__('Specification name : ', 'product-specifications') ?></label>
         <input type="text" name="attr_name" value="<?= esc_attr($term->name) ?>" id="attr_name" aria-required="true">
     </p>
 
     <p>
-        <label for="attr_slug"><?= esc_html__('Attribute slug : ', 'product-specifications') ?></label>
+        <label for="attr_slug"><?= esc_html__('Specification slug : ', 'product-specifications') ?></label>
         <input type="text" name="attr_slug" value="<?= esc_attr(urldecode($term->slug)) ?>" id="attr_slug" placeholder="<?= esc_attr__('Optional', 'product-specifications') ?>">
     </p>
 
     <p>
-        <label for="attr_group"><?= esc_html__('Attribute group : ', 'product-specifications') ?></label>
+        <label for="attr_group"><?= esc_html__('Specification group : ', 'product-specifications') ?></label>
         <select name="attr_group" id="attr_group" aria-required="true">
             <option value=""><?= esc_html__('Select a group', 'product-specifications') ?></option>
             <?php
@@ -53,7 +53,7 @@ $term = get_term_by('id', $attributeId, 'spec-attr');
     </p>
 
     <p>
-        <label for="attr_type"><?= esc_html__('Attribute field Type : ', 'product-specifications') ?></label>
+        <label for="attr_type"><?= esc_html__('Specification field Type : ', 'product-specifications') ?></label>
         <select name="attr_type" id="attr_type" aria-required="true">
             <option value="" <?php selected(false, get_term_meta($term->term_id, 'attr_type', true)) ?>><?= esc_html__('Select a field type', 'product-specifications') ?></option>
             <option value="text" <?php selected('text', get_term_meta($term->term_id, 'attr_type', true)) ?>><?= esc_html__('Text', 'product-specifications') ?>
@@ -88,5 +88,5 @@ $term = get_term_by('id', $attributeId, 'spec-attr');
     <input type="hidden" name="do" value="edit">
     <input name="id" value="<?= esc_attr((string) $attributeId) ?>" type="hidden">
     <?php wp_nonce_field('dwps_modify_attributes', 'dwps_modify_attributes_nonce') ?>
-    <input type="submit" value="<?= esc_attr__('Update attribute', 'product-specifications') ?>" class="button button-primary">
+    <input type="submit" value="<?= esc_attr__('Update Specification', 'product-specifications') ?>" class="button button-primary">
 </form>

--- a/templates/admin/entity-management/group-rearrange-form.php
+++ b/templates/admin/entity-management/group-rearrange-form.php
@@ -32,7 +32,7 @@ defined('ABSPATH') || exit;
         <?php endforeach ?>
 
         <?php if (count($attributes) === 0) : ?>
-            <?= esc_html__('This group has no attributes', 'product-specifications') ?>
+            <?= esc_html__('This group has no specifications', 'product-specifications') ?>
         <?php endif ?>
     </ul>
 

--- a/templates/admin/metabox/product-specs-table/product-attribute-fields.php
+++ b/templates/admin/metabox/product-specs-table/product-attribute-fields.php
@@ -44,7 +44,7 @@ defined('ABSPATH') || exit;
                     ) ?>
                 </ul>
             <?php else : ?>
-                <?= esc_html__('No attributes defined yet', 'product-specifications') ?>
+                <?= esc_html__('No specifications defined yet', 'product-specifications') ?>
             <?php endif ?>
         </div>
     <?php endforeach ?>

--- a/templates/admin/metabox/specifications-table/table-metabox.php
+++ b/templates/admin/metabox/specifications-table/table-metabox.php
@@ -19,10 +19,10 @@ defined('ABSPATH') || exit;
 ?>
 
 <div class="dwsp-meta-wrap">
-    <strong class="title"><?= esc_html__('Attribute Groups : ', 'product-specifications') ?></strong>
+    <strong class="title"><?= esc_html__('Specification Groups : ', 'product-specifications') ?></strong>
     <span class="hint">
         <?= esc_html__(
-            'Select attribute groups you want to load in this table : ',
+            'Select specification groups you want to load in this table : ',
             'product-specifications'
         ) ?>
     </span>

--- a/templates/admin/settings.php
+++ b/templates/admin/settings.php
@@ -18,7 +18,7 @@ defined('ABSPATH') || exit;
 
             <form method="post" action="options.php">
                 <p class="dwps-field-wrap">
-                    <strong class="label"><?= esc_html__('Specs Tab Title', 'product-specifications') ?></strong>
+                    <strong class="label"><?= esc_html__('Specifications tab title', 'product-specifications') ?></strong>
                     <em class="note"><?= esc_html__('The title of product specs. tab in product single page', 'product-specifications') ?></em>
                     <input type="text" name="dwps_tab_title" value="<?= esc_attr(get_option('dwps_tab_title')) ?>">
                 </p>
@@ -30,12 +30,12 @@ defined('ABSPATH') || exit;
                 </p>
 
                 <p class="dwps-field-wrap">
-                    <strong class="label"><?= esc_html__('Woocommerce default specs. behaviour', 'product-specifications') ?></strong>
+                    <strong class="label"><?= esc_html__('Woocommerce default specifications behavior', 'product-specifications') ?></strong>
                     <em class="note"><?= esc_html__('Choose what to do with woocommerce default specifications table', 'product-specifications') ?></em>
 
                     <select name="dwps_wc_default_specs">
                         <option value="remove" <?php selected('remove', get_option('dwps_wc_default_specs')) ?>><?= esc_html__('Always Remove', 'product-specifications') ?></option>
-                        <option value="remove_if_specs_not_empty" <?php selected('remove_if_specs_not_empty', get_option('dwps_wc_default_specs')) ?>><?= esc_html__('Remove if product has a specs. table', 'product-specifications') ?></option>
+                        <option value="remove_if_specs_not_empty" <?php selected('remove_if_specs_not_empty', get_option('dwps_wc_default_specs')) ?>><?= esc_html__('Remove if product has a specification table', 'product-specifications') ?></option>
                         <option value="keep" <?php selected('keep', get_option('dwps_wc_default_specs')) ?>><?= esc_html__('Always keep', 'product-specifications') ?></option>
                     </select>
                 </p>


### PR DESCRIPTION
## Description
Rename entities terminology
- `Attribute` -> **"Specification"**
- `Specification table` -> **"Specification bundle"**

This helps better aligning and avoiding confusion with WooCommerce attributes.

## Summary of changes in this PR
<!-- Use [x] to mark relevant options, feel free to delete lines that are not applicable -->

This PR:
- [ ] **Fixes a bug**
- [ ] **Introduces a new feature**
- [x] **Introduces enhancements in existing functionality**
- [ ] **Updates documents**
- [ ] **Adds or Updates tests**
- [ ] **Introduces BREAKING CHANGES**
